### PR TITLE
cd.. because CMakeLists.txt  is not  build

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ Note: Ubuntu 12.04 is too old to support. Debian jessie may also be too old, and
     make
     make install
     ```
+    Then change directory to parent directory()
+    ```
+    cd ..
+    ```
     You need to specify `cmake -Dfreenect2_DIR=$HOME/freenect2/lib/cmake/freenect2` for CMake based third-party application to find libfreenect2.
 * Set up udev rules for device access: `sudo cp ../platform/linux/udev/90-kinect2.rules /etc/udev/rules.d/`, then replug the Kinect.
 * Run the test program: `./bin/Protonect`


### PR DESCRIPTION
`cmake -Dfreenect2_DIR=$HOME/freenect2/lib/cmake/freenect2` this instruction needs to read information from file _'CMakeLists.txt'_ which should be there in the Present working directory . as we executed  ' `make install` ' from the 'build' directory. and _CMakeLists.txt_ is available in its **parent directory** we need to change directory to parent directory before executing`
 cmake -Dfreenect2_DIR=$HOME/freenect2/lib/cmake/freenect2`